### PR TITLE
Add rake tasks for importing and refreshing users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
 	require 'open-uri'
 	# name, site_streak, language, language_level
 
+	validates :name, uniqueness: true
 	has_many :language_progresses
 
 	attr_accessor :api_hash

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,11 @@ class User < ActiveRecord::Base
 
 	attr_accessor :api_hash
 
+	def populate_from_refresh(api_hash)
+		self.update(streak: api_hash["site_streak"])
+		self.create_language_progresses(api_hash)
+	end
+
 	def self.populate(duo_username)
 		api_hash = self.api_call(duo_username)
 		binding.pry

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,26 @@
+require 'open-uri'
+
+namespace :users do
+  task import_from_thread: :environment do
+
+    url = "https://www.duolingo.com/comments/7429832"
+    json = JSON.load(open(url))
+    message = json["marked_down_message"]
+    page = Nokogiri::HTML(message)
+    links = page.css('a')
+    names = links.map do |link| link.text end
+                 .select do |link_text| !link_text.match(/\s/) end
+
+    names.each do |name|
+      User.create(name: name)
+    end
+
+  end
+
+  task refresh_from_api: :environment do
+    User.find_each(batch_size: 10) do |user|
+    end
+
+
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -19,8 +19,13 @@ namespace :users do
 
   task refresh_from_api: :environment do
     User.find_each(batch_size: 10) do |user|
+      begin
+        api_hash = User.api_call(user.name)
+      rescue
+        next
+      end
+      User.find_by_name(user.name).populate_from_refresh(api_hash)
+      puts 'refreshed ' + user.name + ' from the api'
     end
-
-
   end
 end


### PR DESCRIPTION
I've added two rake tasks
1. `user:import_from_thread` - this rake task looks at the jitengore thread's first post, pulls all of the usernames and saves them as new/empty users. 
2. `user:refresh_from_api` - this rake task pulls all users in batches and fetches/populates the users streak and language progress from the duolingo API

This will resolve #2 
